### PR TITLE
Meta table

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ The `github-backup` server will receive events from Github and then save the det
   export PRIVATE_KEY=YOUR_PRIVATE_KEY
   # Your GITHUB_APP_ID is found in the settings of your github app under General > About
   export GITHUB_APP_ID=YOUR_GITHUB_APP_ID
+  export GITHUB_APP_NAME=NAME_OF_THE_GITHUB_APP
+  export APP_HOST=localhost
   ```
 
   You can generate a new secret key base with ```mix phoenix.gen.secret```.

--- a/assets/static/images/edit_count.svg
+++ b/assets/static/images/edit_count.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">
+<!-- grey rect -->
+<rect width="70" height="20" fill="#555"/>
+<!-- green rect -->
+<rect x="70" width="50" height="20" fill="#4c1"/>
+
+<rect rx="3" width="200" height="20" fill="transparent"/>
+	<g fill="#fff" text-anchor="middle"
+    font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+	    <text x="35" y="14">Edit Count</text>
+	    <text x="94" y="14">{count}</text>
+	</g>
+</svg>

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,6 +22,8 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+config :app, :github_app_name, Map.fetch!(System.get_env(), "GITHUB_APP_NAME")
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,7 +11,7 @@ config :app,
 
 # Configures the endpoint
 config :app, AppWeb.Endpoint,
-  url: [host: "localhost"],
+  url: [host: Map.fetch!(System.get_env(), "APP_HOST")],
   secret_key_base: Map.fetch!(System.get_env(), "SECRET_KEY_BASE"),
   render_errors: [view: AppWeb.ErrorView, accepts: ~w(html json)],
   pubsub: [name: App.PubSub,

--- a/lib/app_web/controllers/edit_count_controller.ex
+++ b/lib/app_web/controllers/edit_count_controller.ex
@@ -7,9 +7,9 @@ defmodule AppWeb.EditCountController do
 
     issue  = Repo.get_by!(Issue, issue_id: issue_id)
     issue = issue
-      |> Repo.preload([
-          comments: [:verions]
-        ])
+            |> Repo.preload([
+                comments: [:versions]
+              ])
 
     comment_versions = Enum.map(issue.comments, fn c ->
       length(c.versions)

--- a/lib/app_web/controllers/edit_count_controller.ex
+++ b/lib/app_web/controllers/edit_count_controller.ex
@@ -1,0 +1,26 @@
+defmodule AppWeb.EditCountController do
+  use AppWeb, :controller
+  alias App.{Issue, Repo}
+
+  def show(conn, payload) do
+    issue_id = payload["issue_id"]
+
+    issue  = Repo.get_by!(Issue, issue_id: issue_id)
+    issue = issue
+      |> Repo.preload([
+          comments: [:verions]
+        ])
+
+    comment_versions = Enum.map(issue.comments, fn c ->
+      length(c.versions)
+    end)
+
+    count = Enum.sum(comment_versions) - length(issue.comments)
+
+    svg = File.read!("./assets/static/images/edit_count.svg")
+    svg = String.replace(svg, ~r/{count}/, to_string(count))
+    conn
+    |> put_resp_content_type("image/svg+xml")
+    |> send_resp(200, svg)
+  end
+end

--- a/lib/app_web/controllers/event_type_handlers.ex
+++ b/lib/app_web/controllers/event_type_handlers.ex
@@ -47,7 +47,7 @@ defmodule AppWeb.EventTypeHandlers do
     @s3_api.save_comment(issue.issue_id, content)
 
     meta_table = MetaTable.get_meta_table(payload["issue"]["id"])
-    content = comment <> "\n" <> meta_table
+    content = comment <> "\r\n\n" <> meta_table
     repo_name = payload["repository"]["full_name"]
     issue_number = payload["issue"]["number"]
     token = @github_api.get_installation_token(payload["installation"]["id"])

--- a/lib/app_web/controllers/event_type_handlers.ex
+++ b/lib/app_web/controllers/event_type_handlers.ex
@@ -66,7 +66,9 @@ defmodule AppWeb.EventTypeHandlers do
           issue = Changeset.change issue, title: payload["issue"]["title"]
           Repo.update!(issue)
       end
-      
+
+      body_change = Map.has_key?(payload["changes"], "body")
+      not_bot = payload["sender"]["login"] != @github_app_name <> "[bot]"
       if body_change && not_bot do
         comment = payload["issue"]["body"]
         author = payload["sender"]["login"]

--- a/lib/app_web/controllers/github_api/http_client.ex
+++ b/lib/app_web/controllers/github_api/http_client.ex
@@ -64,6 +64,11 @@ defmodule AppWeb.GithubAPI.HTTPClient do
     |> PP.parse!
   end
 
+  def add_meta_table(repo_name, issue_id, content, token) do
+    "#{@github_root}/repos/#{repo_name}/issues/#{issue_id}"
+    |> HTTPoison.patch!(Poison.encode!(%{body: content}), header(token))
+  end
+
   defp last_page?(headers) do
     links_header = Map.get(Enum.into(headers, %{}), "Link")
 

--- a/lib/app_web/controllers/github_api/in_memory.ex
+++ b/lib/app_web/controllers/github_api/in_memory.ex
@@ -15,4 +15,7 @@ defmodule AppWeb.GithubAPI.InMemory do
     []
   end
 
+  def add_meta_table(repo_name, issue_id, content, token) do
+    :ok
+  end
 end

--- a/lib/app_web/controllers/meta_table.ex
+++ b/lib/app_web/controllers/meta_table.ex
@@ -1,8 +1,12 @@
 defmodule AppWeb.MetaTable do
 
   def get_meta_table(issue_id) do
-    # return the number of all edits
-    # get all the versions link to the issue
-    "Issue Edit Count: 9 | View History: link_to_the_app"
+    count = AppWeb.Endpoint.url <> "/edit-count/#{issue_id}"
+    history = AppWeb.Endpoint.url <> "/issues/#{issue_id}"
+    """
+    | Edits | View issue history |
+    |-|-|
+    |[![Edit Count](#{count})](#{count}) | **View History:** [#{history}](#{history})|
+    """
   end
 end

--- a/lib/app_web/controllers/meta_table.ex
+++ b/lib/app_web/controllers/meta_table.ex
@@ -1,0 +1,8 @@
+defmodule AppWeb.MetaTable do
+
+  def get_meta_table(issue_id) do
+    # return the number of all edits
+    # get all the versions link to the issue
+    "Issue Edit Count: 9 | View History: link_to_the_app"
+  end
+end

--- a/lib/app_web/router.ex
+++ b/lib/app_web/router.ex
@@ -20,13 +20,16 @@ defmodule AppWeb.Router do
     get "/comments/:id", CommentController, :show
   end
 
+  scope "/", AppWeb do
+    pipe_through :api
+
+    get "/edit-count/:issue_id", EditCountController, :show
+  end
+
   scope "/event", AppWeb do
     pipe_through :api
 
     post "/new", EventController, :new
   end
-  # Other scopes may use custom stacks.
-  # scope "/api", AppWeb do
-  #   pipe_through :api
-  # end
+
 end

--- a/test/app_web/controllers/edit_count_controller_test.exs
+++ b/test/app_web/controllers/edit_count_controller_test.exs
@@ -1,0 +1,32 @@
+defmodule AppWeb.EditCountControllerTest do
+  use AppWeb.ConnCase
+  alias App.{Issue, Repo}
+
+  describe "get svg count for an issue" do
+    setup do
+      issue_params = %{
+        issue_id: 2,
+        title: "Test issue title",
+        comments: [
+          %{
+            comment_id: "2_1",
+            versions: [%{author: "SimonLab"}]
+          },
+          %{
+            comment_id: "1111",
+            versions: [%{author: "SimonLab"}]
+          }
+        ]
+      }
+
+      changeset = Issue.changeset(%Issue{}, issue_params)
+      issue = Repo.insert!(changeset)
+      {:ok, conn: build_conn() |> assign(:issue, issue)}
+    end
+
+    test "GET /edit-count/2", %{conn: conn} do
+      conn = get conn, "edit-count/2"
+      assert response(conn, 200) =~ "Edit Count"
+    end
+  end
+end


### PR DESCRIPTION
ref: #14 #77 
Generate svg from /edit-count/{issue_id} endpoint which is then added on the bottom of the issue description.
The edit number is the sum of all the edits on the comments and issue description