### PR TITLE
#59 Issue title ui

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -28,18 +28,6 @@
 	margin-top: -8px;
 }
 
-@media (max-width: 26em) {
-  .comment-minw {
-    min-width: 85%;
-  }
-}
-
-@media (min-width: 26em) {
-  .comment-minw {
-    min-width: 94.2%;
-  }
-}
-
 .markdown_text p, .markdown_text h1 {
   line-height: 1.5;
   padding: 1rem;
@@ -47,10 +35,6 @@
 }
 
 /* Tachyons custom classes */
-
-.ml5-5 {
-  margin-left: 5.5rem;
-}
 
 .lh-1-25 {
   line-height: 1.25rem;

--- a/lib/app_web/templates/comment/index.html.eex
+++ b/lib/app_web/templates/comment/index.html.eex
@@ -1,36 +1,40 @@
-<section class="tc center pb2 mb4 w-100 w-60-ns bb gh-b--light-gray">
-  <h1 class="pb3">Github Backup</h1>
-  <h2 class="f2 tl pl3 pl0-ns"><%= @comment_details.issue.title %></h2>
-</section>
+<section class="w-90 w-50-ns center">
+  <div class="tc center pb2 mb4 bb gh-b--light-gray">
+    <h1 class="pb3">Github Backup</h1>
+    <h2 class="f2 tl"><%= @comment_details.issue.title %></h2>
+  </div>
 
-<section class="tc">
-  <%= if @comment_details.deleted == true do %>
-  <p class="gh-gray f3 w-90 w-100-ns center pv3 mb0">
-    <i class="fas fa-trash pa3 mr2 bg-light-gray tc br-100"></i>
-    <strong><%= @comment_details.deleted_by %></strong>
-    deleted this comment on <%= format_date @comment_details.updated_at %>
-  </p>
-  <% end %>
+  <section class="tc">
 
-  <%= for {version, i} <- Enum.with_index(@comment_details.versions) do %>
+    <%= if @comment_details.deleted == true do %>
+      <p class="gh-gray f3 center pv3 mb0">
+        <i class="fas fa-trash pa3 mr2 bg-light-gray tc br-100"></i>
+        <strong><%= @comment_details.deleted_by %></strong>
+        deleted this comment on <%= format_date @comment_details.updated_at %>
+      </p>
+    <% end %>
 
-    <section class="pv3 tl relative w-90 w-50-ns center">
-      <div class="dib br2 mr3 mv0 absolute top-1 left-0">
-        <img class="br2 w3"src="/images/user_avatar.png" alt="username image">
+    <%= for {version, i} <- Enum.with_index(@comment_details.versions) do %>
+
+      <div class="flex">
+        <div class="mv3 w3">
+          <img class="br2"src="/images/user_avatar.png" alt="user avatar">
+        </div>
+        <%= if i != 0 do %>
+          <div class="ml3 mv3 tl w-100 ba gh-b--light-gray br2 comment relative bg-moon-gray">
+          <% else %>
+            <div class="ml3 mv3 tl w-100 ba gh-b--light-gray br2 comment relative">
+          <% end %>
+          <p class="pa3 bb gh-b--light-gray bg-light-gray gh-gray mb0 cf">
+            <strong><%= version.author %></strong>
+            commented <%= format_date version.inserted_at %>
+          </p>
+          <span class="mv0 markdown_text">
+            <%= display_markdown(@comments_text["#{version.id}"]) %>
+          </span>
+        </div>
       </div>
-      <%= if i != 0 do %>
-        <div class="tl dib ba gh-b--light-gray br2 relative comment ml5-5 comment-minw bg-moon-gray">
-      <% else %>
-        <div class="tl dib ba gh-b--light-gray br2 relative comment ml5-5 comment-minw">
-      <% end %>
-        <p class="pa3 bb gh-b--light-gray bg-light-gray gh-gray mb0 cf">
-          <strong><%= version.author %></strong>
-          commented <%= format_date version.inserted_at %>
-        </p>
-        <span class="mv0 markdown_text">
-          <%= display_markdown(@comments_text["#{version.id}"]) %>
-        </span>
-      </div>
-    </section>
-  <% end %>
+    <% end %>
+  </section>
+
 </section>

--- a/lib/app_web/templates/comment/index.html.eex
+++ b/lib/app_web/templates/comment/index.html.eex
@@ -1,11 +1,11 @@
-<section class="tc pb4">
-  <h1>Github Backup</h1>
-  <h2 class="f2"><%= @comment_details.issue.title %></h2>
+<section class="tc center pb2 mb4 w-100 w-60-ns bb gh-b--light-gray">
+  <h1 class="pb3">Github Backup</h1>
+  <h2 class="f2 tl pl3 pl0-ns"><%= @comment_details.issue.title %></h2>
 </section>
 
 <section class="tc">
   <%= if @comment_details.deleted == true do %>
-  <p class="gh-gray f3">
+  <p class="gh-gray f3 w-90 w-100-ns center pv3 mb0">
     <i class="fas fa-trash pa3 mr2 bg-light-gray tc br-100"></i>
     <strong><%= @comment_details.deleted_by %></strong>
     deleted this comment on <%= format_date @comment_details.updated_at %>
@@ -14,8 +14,8 @@
 
   <%= for {version, i} <- Enum.with_index(@comment_details.versions) do %>
 
-    <section class="pb4 tl relative w-90 w-50-ns center">
-      <div class="dib br2 mr3 mv0 absolute top-0 left-0">
+    <section class="pv3 tl relative w-90 w-50-ns center">
+      <div class="dib br2 mr3 mv0 absolute top-1 left-0">
         <img class="br2 w3"src="/images/user_avatar.png" alt="username image">
       </div>
       <%= if i != 0 do %>


### PR DESCRIPTION
**Merge after #79** 

#59 Adds underline and brings text left on the issue title to make the UI more like the github UI. Leads to refactoring on comment cards to use flexbox so that all elements are in line with one another as they should be.

