### PR TITLE
Update inserted at

### DIFF
--- a/lib/app/comment.ex
+++ b/lib/app/comment.ex
@@ -20,7 +20,7 @@ defmodule App.Comment do
   @doc false
   def changeset(%Comment{} = comment, attrs \\ %{}) do
     comment
-    |> cast(attrs, [:comment_id])
+    |> cast(attrs, [:comment_id, :inserted_at, :updated_at])
     |> cast_assoc(:versions, require: true)
     |> validate_required([:comment_id])
   end

--- a/lib/app/helpers/issue.ex
+++ b/lib/app/helpers/issue.ex
@@ -34,8 +34,14 @@ defmodule App.Helpers.IssueHelper do
     |> Enum.map(fn i ->
       comment_issue = %{
         comment_id: "#{i.issue_id}_1",
-        versions: [%{author: i.issue_author}],
-        comment: i.description
+        versions: [%{
+          author: i.issue_author,
+          inserted_at: i.inserted_at,
+          updated_at: i.updated_at
+          }],
+        comment: i.description,
+        inserted_at: i.inserted_at,
+        updated_at: i.updated_at,
       }
       comments = [comment_issue | i.comments]
       Map.put(i, :comments, comments)

--- a/lib/app/issue.ex
+++ b/lib/app/issue.ex
@@ -18,7 +18,7 @@ defmodule App.Issue do
   @doc false
   def changeset(%Issue{} = issue, attrs) do
     issue
-    |> cast(attrs, [:issue_id, :title])
+    |> cast(attrs, [:issue_id, :title, :inserted_at, :updated_at])
     |> cast_assoc(:comments, require: true)
     |> validate_required([:issue_id, :title])
   end

--- a/lib/app/version.ex
+++ b/lib/app/version.ex
@@ -17,7 +17,7 @@ defmodule App.Version do
   @doc false
   def changeset(%Version{} = version, attrs) do
     version
-    |> cast(attrs, [:author])
+    |> cast(attrs, [:author, :inserted_at, :updated_at])
     |> validate_required([:author])
   end
 end

--- a/lib/app_web/controllers/event_type_handlers.ex
+++ b/lib/app_web/controllers/event_type_handlers.ex
@@ -43,6 +43,7 @@ defmodule AppWeb.EventTypeHandlers do
           title: i["title"],
           description: i["body"],
           issue_author: i["user"]["login"],
+          created_at: i["created_at"],
           comments: Enum.map(i["comments"], fn c ->
             %{
               comment_id: "#{c["id"]}",
@@ -66,6 +67,8 @@ defmodule AppWeb.EventTypeHandlers do
     # save issue
     Enum.each(issues, fn i ->
       changeset = Issue.changeset(%Issue{}, i)
+      time = NaiveDateTime.from_iso8601!(i.created_at)
+      changeset = Changeset.put_change(changeset, :inserted_at, time)
       issue = Repo.insert!(changeset)
 
       s3_data = IssueHelper.get_s3_content(issue, comments_body)

--- a/lib/app_web/controllers/event_type_handlers.ex
+++ b/lib/app_web/controllers/event_type_handlers.ex
@@ -43,12 +43,19 @@ defmodule AppWeb.EventTypeHandlers do
           title: i["title"],
           description: i["body"],
           issue_author: i["user"]["login"],
-          created_at: i["created_at"],
+          inserted_at: NaiveDateTime.from_iso8601!(i["created_at"]),
+          updated_at: NaiveDateTime.from_iso8601!(i["created_at"]),
           comments: Enum.map(i["comments"], fn c ->
             %{
               comment_id: "#{c["id"]}",
-              versions: [%{author: c["user"]["login"]}],
-              comment: c["body"]
+              versions: [%{
+                author: c["user"]["login"],
+                inserted_at: NaiveDateTime.from_iso8601!(c["created_at"]),
+                updated_at: NaiveDateTime.from_iso8601!(c["created_at"])
+              }],
+              comment: c["body"],
+              inserted_at: NaiveDateTime.from_iso8601!(c["created_at"]),
+              updated_at: NaiveDateTime.from_iso8601!(c["created_at"])
             }
           end)
         }
@@ -67,8 +74,6 @@ defmodule AppWeb.EventTypeHandlers do
     # save issue
     Enum.each(issues, fn i ->
       changeset = Issue.changeset(%Issue{}, i)
-      time = NaiveDateTime.from_iso8601!(i.created_at)
-      changeset = Changeset.put_change(changeset, :inserted_at, time)
       issue = Repo.insert!(changeset)
 
       s3_data = IssueHelper.get_s3_content(issue, comments_body)

--- a/lib/app_web/templates/comment/index.html.eex
+++ b/lib/app_web/templates/comment/index.html.eex
@@ -10,7 +10,7 @@
       <p class="gh-gray f3 center pv3 mb0">
         <i class="fas fa-trash pa3 mr2 bg-light-gray tc br-100"></i>
         <strong><%= @comment_details.deleted_by %></strong>
-        deleted this comment on <%= format_date @comment_details.updated_at %>
+        deleted this comment on <%= format_date @comment_details.inserted_at %>
       </p>
     <% end %>
 

--- a/lib/app_web/templates/issue/index.html.eex
+++ b/lib/app_web/templates/issue/index.html.eex
@@ -11,7 +11,7 @@
         <p class="gh-gray f3 center pv3 mb0">
           <i class="fas fa-trash pa3 mr2 bg-light-gray tc br-100"></i>
           <strong><%= comment.deleted_by %></strong>
-          deleted this comment on <%= format_date comment.updated_at %>
+          deleted this comment on <%= format_date comment.inserted_at %>
         </p>
       <% end %>
 

--- a/test/app_web/helpers/issue_test.exs
+++ b/test/app_web/helpers/issue_test.exs
@@ -40,6 +40,8 @@ defmodule AppWeb.IssueHelperTest do
         issue_id: "1",
         issue_author: "me",
         description: "new issue",
+        inserted_at: "2018",
+        updated_at: "2018",
         comments: []
       }
     ]
@@ -48,11 +50,21 @@ defmodule AppWeb.IssueHelperTest do
         issue_id: "1",
         issue_author: "me",
         description: "new issue",
+        inserted_at: "2018",
+        updated_at: "2018",
         comments: [
           %{
             comment_id: "1_1",
             comment: "new issue",
-            versions: [%{author: "me"}]
+            inserted_at: "2018",
+            updated_at: "2018",
+            versions: [
+              %{
+                author: "me",
+                inserted_at: "2018",
+                updated_at: "2018"
+                }
+              ]
           }
         ]
       }


### PR DESCRIPTION
ref: #93 
When saving all issues/comments when the app is isntall on repos, the values updated_at and inserted_at are updated manually (instead of letting Postgres do it) with the value when the issues/comments were created